### PR TITLE
Document variable usage in Display Background Text plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Renders a line of text at a specified position in the scene background.
 
 There's no maximum character length for the text, but the total amount of displayed characters in a scene is limited to by the number of tiles reserved for UI text (52 for non-color mode), this includes text displayed with this event but also any other dialogue or menu.
 
+Unfortunately autocomplete of variables isn't available for single line textboxes in plugins so you need to use $xxx$ to render variables, for example $100 to render variable 100.
+
 <img width="300" alt="Mute Channel" src="screenshots/background_text.png"/>
 
 ## Printer

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Renders a line of text at a specified position in the scene background.
 
 There's no maximum character length for the text, but the total amount of displayed characters in a scene is limited to by the number of tiles reserved for UI text (52 for non-color mode), this includes text displayed with this event but also any other dialogue or menu.
 
-Unfortunately autocomplete of variables isn't available for single line textboxes in plugins so you need to use $xxx$ to render variables, for example $100 to render variable 100.
+Unfortunately, autocomplete of variables isn't available for single line textboxes in plugins. Use `$xxx$` to render a variable as part of the text, for example `$100` to render the value of `Variable 100`.
 
-<img width="300" alt="Mute Channel" src="screenshots/background_text.png"/>
+<img width="300" alt="Background Text" src="screenshots/background_text.png"/>
 
 ## Printer
 


### PR DESCRIPTION
This PR simply takes the helpful answer from https://github.com/pau-tomas/gb-studio-plugins/issues/1 and puts it in the README.