### PR TITLE
Added Advanced Dialog box Width with alignment

### DIFF
--- a/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
+++ b/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
@@ -86,9 +86,9 @@ const fields = [].concat(
       defaultValue: "100-full",
       options: [
         ["100-full", "Full"],
-        ["50-left", "50% Left Aligned"],
+        //["50-left", "50% Left Aligned"],
         ["50-right", "50% Right Aligned"],
-        ["75-left", "75% Left Aligned"],
+        //["75-left", "75% Left Aligned"],
         ["75-right", "75% Right Aligned"],
       ],
       conditions: [

--- a/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
+++ b/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
@@ -80,6 +80,25 @@ const fields = [].concat(
       ],
     },
     {
+      key: `boxWidth`,
+      label: "Width",
+      type: "select",
+      defaultValue: "100-full",
+      options: [
+        ["100-full", "Full"],
+        ["50-left", "50% Left Aligned"],
+        ["50-right", "50% Right Aligned"],
+        ["75-left", "75% Left Aligned"],
+        ["75-right", "75% Right Aligned"],
+      ],
+      conditions: [
+        {
+          key: "__scriptTabs",
+          in: ["layout"],
+        },
+      ],
+    },
+    {
       type: "group",
       conditions: [
         {
@@ -260,6 +279,11 @@ const compile = (input, helpers) => {
   const textY = input.textY === null ? 1 : input.textY;
   const textHeight = input.textHeight === null ? 3 : input.textHeight;
   const renderOnTop = input.position === "top";
+  const renderWidth = input.boxWidth || "100-full";
+  const renderOverlay = {
+    xOffset: 0,
+    width: 20,
+  };
   const isModal = input.closeWhen !== "notModal";
 
   console.log(input);
@@ -282,6 +306,29 @@ const compile = (input, helpers) => {
   );
 
   console.log(minHeight, minNumLines, maxHeight);
+
+  switch (renderWidth) {
+    case "100-full":
+      renderOverlay.xOffset = 0;
+      renderOverlay.width = 20;
+      break;
+    case "50-left":
+      renderOverlay.xOffset = 0;
+      renderOverlay.width = 10;
+      break;
+    case "50-right":
+      renderOverlay.xOffset = 10;
+      renderOverlay.width = 10;
+      break;
+    case "75-left":
+      renderOverlay.xOffset = 0;
+      renderOverlay.width = 15;
+      break;
+    case "75-right":
+      renderOverlay.xOffset = 5;
+      renderOverlay.width = 15;
+      break;
+  }
 
   const textBoxHeight = Math.max(minNumLines, minHeight);
   const textBoxY = renderOnTop ? 0 : 18 - textBoxHeight;
@@ -325,15 +372,23 @@ VM_SET_CONST_UINT8 _overlay_cut_scanline, ${textBoxHeight * 8 - 1}`);
       _overlayClear(
         0,
         0,
-        20,
+        renderOverlay.width,
         textBoxHeight,
         ".UI_COLOR_WHITE",
         input.showBorder
       );
     }
 
+    // If there's an offset then we need to offset the starting position of the overlay.
+    // Use -3 for speed to instantly move the overlay to just below the screen with the correct offsets.
+    // If we don't do this then the overlay will move in from the bottom left across the screen instead of straight up
+    if (renderOverlay.xOffset > 0) {
+      _overlayMoveTo(renderOverlay.xOffset, 18, -3);
+    }
+
+    // Now push the overlay up with the correct offsets
     if (textIndex === 0) {
-      _overlayMoveTo(0, textBoxY, speedIn);
+      _overlayMoveTo(renderOverlay.xOffset, textBoxY, speedIn);
     }
 
     appendRaw(
@@ -363,7 +418,7 @@ VM_SET_CONST_UINT8 _overlay_cut_scanline, ${textBoxHeight * 8 - 1}`);
 
     if (textIndex === textInputs.length - 1) {
       if (isModal) {
-        _overlayMoveTo(0, 18, speedOut);
+        _overlayMoveTo(renderOverlay.xOffset, 18, speedOut);
         _overlayWait(isModal, [".UI_WAIT_WINDOW", ".UI_WAIT_TEXT"]);
       }
     }

--- a/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
+++ b/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
@@ -393,7 +393,10 @@ VM_SET_CONST_UINT8 _overlay_cut_scanline, ${textBoxHeight * 8 - 1}`);
 
     appendRaw(
       `VM_OVERLAY_SET_SCROLL   ${textX + (avatarId ? 3 : 0)}, ${textY}, ${
-        (input.showBorder ? 19 : 20) - (avatarId ? 3 : 0) - textX
+        (input.showBorder ? 19 : 20) -
+        (avatarId ? 3 : 0) -
+        textX -
+        renderOverlay.xOffset
       }, ${textHeight}, .UI_COLOR_WHITE`
     );
 

--- a/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
+++ b/plugins/Advanced Dialogue/events/eventAdvancedDialogue.js
@@ -382,7 +382,7 @@ VM_SET_CONST_UINT8 _overlay_cut_scanline, ${textBoxHeight * 8 - 1}`);
     // If there's an offset then we need to offset the starting position of the overlay.
     // Use -3 for speed to instantly move the overlay to just below the screen with the correct offsets.
     // If we don't do this then the overlay will move in from the bottom left across the screen instead of straight up
-    if (renderOverlay.xOffset > 0) {
+    if (textIndex === 0 && renderOverlay.xOffset > 0) {
       _overlayMoveTo(renderOverlay.xOffset, 18, -3);
     }
 


### PR DESCRIPTION
Added a new "Width" option to the "Advanced Dialog" event. This new option provides a dropdown with Full width, 50% right aligned, and 75% width  right aligned.

Tested on GBStudio 3.2.1 and confirmed working for both top position dialogs and bottom position dialogs.

I couldn't get left alignment to work due to screen artifacts on the right side unfortunately.

![image](https://github.com/pau-tomas/gb-studio-plugins/assets/3596964/6c7763c8-c09e-47fe-b0ec-d06c55313053)
![image](https://github.com/pau-tomas/gb-studio-plugins/assets/3596964/08e314cd-7fa7-4a20-a3fa-967076bebf0f)
